### PR TITLE
Check that node_modules exists before installing py package.

### DIFF
--- a/{{cookiecutter.github_project_name}}/lib/plugin.js
+++ b/{{cookiecutter.github_project_name}}/lib/plugin.js
@@ -2,6 +2,7 @@ module.exports = [{
     id: '{{ cookiecutter.extension_name }}',
     autoStart: true,
     activate: function(app) {
-       console.log(app.commands);
+      console.log('{{ cookiecutter.extension_name }} extension is active.');
+      console.log(app.commands);
     }
 }];

--- a/{{cookiecutter.github_project_name}}/setup.py
+++ b/{{cookiecutter.github_project_name}}/setup.py
@@ -1,9 +1,24 @@
+import os
 import sys
 from distutils.core import setup
 
 
+class NodeModulesMissing(Exception):
+    "raised when node_modules directory is not found"
+    pass
+
+
 if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):
     import setuptools
+
+# Ensure that js has been built. This does not guaruntee that the packages
+# are update to date. In the future we might do a more expensive check
+# involving file hashes, but only on sdist and bdist builds.
+if not os.path.exists('node_modules'):
+    raise NodeModulesMissing("Before Python package can be installed, "
+                             "JavaScript components must be build using npm. "
+                             "Run the following and then retry: "
+                             "\nnpm install\nnpm run build")
 
 setup_args = dict(
     name                 = '{{ cookiecutter.python_package_name }}',


### PR DESCRIPTION
If `setup.py` is run but `node_modules` directory is not present, developer will now see the following:

```
$ pip install -e .
Obtaining file:///Users/dallan/Documents/Repos/working4/working4
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/Users/dallan/Documents/Repos/working4/working4/setup.py", line 18, in <module>
        raise NodeModulesMissing("Before Python package can be installed, "
    __main__.NodeModulesMissing: Before Python package can be installed, JavaScript components must be build using npm. Run the following and then retry:
    npm install
    npm run build

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /Users/dallan/Documents/Repos/working4/working4/
```
