### PR TITLE
Ensure packge keyword "jupyterlab extension"

### DIFF
--- a/{{cookiecutter.extension_name}}/package.json
+++ b/{{cookiecutter.extension_name}}/package.json
@@ -8,7 +8,7 @@
   "keywords": [
     "jupyter",
     "jupyterlab",
-    "jupyterlab extension"
+    "jupyterlab-extension"
   ],
   "jupyterlab": {
     "extension": true

--- a/{{cookiecutter.extension_name}}/package.json
+++ b/{{cookiecutter.extension_name}}/package.json
@@ -7,7 +7,8 @@
   "main": "lib/plugin.js",
   "keywords": [
     "jupyter",
-    "jupyterlab"
+    "jupyterlab",
+    "jupyterlab extension"
   ],
   "jupyterlab": {
     "extension": true


### PR DESCRIPTION
This should help with discoverability of extensions, as it is a very specific keyword.