### PR TITLE
Update to node 12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install node
       uses: actions/setup-node@v1
       with:
-       node-version: '10.x'
+       node-version: '12.x'
     - name: Install Python
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
To fix the recurring jobs that have recently started to fail now that JupyterLab 3.0 has been published.