### PR TITLE
Remove dot for JS extension in files glob pattern of package.json

### DIFF
--- a/{{cookiecutter.python_name}}/package.json
+++ b/{{cookiecutter.python_name}}/package.json
@@ -18,7 +18,7 @@
   },
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
-    "style/**/*.{css,.js,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+    "style/**/*.{css,js,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
   "main": "lib/index.js",
   "style": "style/index.css",


### PR DESCRIPTION
This caused JavaScript files in the `style` folder from not being included in the package, such as the `index.js` file from the bootstrap code, which then brakes the `jupyter labextension install` script. 